### PR TITLE
updates for baseline configurations of CV scan

### DIFF
--- a/Kei2400CControl.py
+++ b/Kei2400CControl.py
@@ -7,7 +7,7 @@ class keithley2400c:
         instlist=visa.ResourceManager()
         print(instlist.list_resources())
         self.kei2400c=instlist.open_resource(resource_name)
-        self.timedelay=0.5
+        #self.timedelay=0.5
         self.cmpl='105E-6' # global current protection
 
     def testIO(self):
@@ -22,13 +22,11 @@ class keithley2400c:
         self.kei2400c.write(":source:voltage:range "+str(vol))
 
     def set_voltage(self,vol):
-        #if vol > 2.0:
-		#    warnings.warn("Warning High Voltage!!!!")
         self.kei2400c.write(":sense:current:protection "+self.cmpl)
         self.kei2400c.write(":source:function voltage")
         self.kei2400c.write(":source:voltage:mode fixed")
         vols=self.show_voltage()
-        self.sweep(vols,vol,1)
+        self.sweep(vols,vol,0.1)
         vols=self.show_voltage()
         return vols
 
@@ -48,47 +46,47 @@ class keithley2400c:
     def sweep_forward(self, vols, vole, step):
         # Conveter from V to mV
         mvols=vols*1000
-        mvole=vole*1000
+        mvole=vole*1000+1
         mstep=step*1000
 
         for mvol in range(int(mvols),int(mvole),int(mstep)):
             vol=mvol/1000 # mV -> V
             self.kei2400c.write(":source:voltage:level "+str(vol))
-            self.kei2400c.write(":sense:current:protection "+self.cmpl)
-            self.show_voltage()
-            time.sleep(self.timedelay)
+            #self.kei2400c.write(":sense:current:protection "+self.cmpl)
+            #self.show_voltage()
+            time.sleep(0.1)
 
-        self.kei2400c.write(":source:voltage:level "+str(vole))
-        self.show_voltage()
+        #self.kei2400c.write(":source:voltage:level "+str(vole))
+        #self.show_voltage()
 
     def sweep_backward(self, vols, vole, step):
         # Conveter from V to mV
         mvols=vols*1000
-        mvole=vole*1000
+        mvole=vole*1000-1
         mstep=step*1000
 
         for mvol in range(int(mvols),int(mvole), -int(mstep)):
             vol=mvol/1000 # mV -> V
             self.kei2400c.write(":source:voltage:level "+str(vol))
-            self.kei2400c.write(":sense:current:protection "+self.cmpl)
-            self.show_voltage()
-            time.sleep(self.timedelay*0.2)
+            #self.kei2400c.write(":sense:current:protection "+self.cmpl)
+            #self.show_voltage()
+            time.sleep(0.1)
 
-        self.kei2400c.write(":source:voltage:level "+str(vole))
-        self.show_voltage()
+        #self.kei2400c.write(":source:voltage:level "+str(vole))
+        #self.show_voltage()
 
     def display_current(self):
         self.kei2400c.write(":sense:function 'current'")
         self.kei2400c.write(":sense:current:range "+self.cmpl)
         self.kei2400c.write(":display:enable on")
         self.kei2400c.write(":display:digits 7")
+        #self.kei2400c.write(":form:elem current")
+        #current=self.kei2400c.query(":read?")
+
+        #time.sleep(0.5)
         self.kei2400c.write(":form:elem current")
         current=self.kei2400c.query(":read?")
         print("current [A]:  " + str(current))
-
-        time.sleep(self.timedelay)
-        self.kei2400c.write(":form:elem current")
-        current=self.kei2400c.query(":read?")
         return float(str(current))
 
     def hit_compliance(self):
@@ -105,6 +103,9 @@ class keithley2400c:
         self.kei2400c.write(":output off")
         print("Off")
 
+    def beep(self, freq=1046.50, duration=0.3):
+        self.kei2400c.write(":system:beeper "+str(freq)+", "+str(duration))
+        time.sleep(duration)
 
 if __name__=="__main__":
     kei2400c=keithley2400c("ASRL1::INSTR")

--- a/KeyE4980AControl.py
+++ b/KeyE4980AControl.py
@@ -38,3 +38,4 @@ class keysighte4980a:
 if __name__=="__main__":
     lcr=keysighte4980a("USB0::0x2A8D::0x2F01::MY46516486::INSTR")
     lcr.testIO()
+    lcr.set_trigger_internal()

--- a/scanIV.py
+++ b/scanIV.py
@@ -23,9 +23,9 @@ if platform.python_version().startswith('2'):
 
 biasSupply=kei2400.keithley2400c("ASRL1::INSTR")
 biasSupply.set_current_protection(100E-6) # current protection in A
-biasSupply.set_voltage_protection(500) # voltage protection in V
+biasSupply.set_voltage_protection(200) # voltage protection in V
 positiveHV=False # sign of the voltage
-HVrange=10.0*1e3  # voltage scan range in mV in absolute value
+HVrange=150.0*1e3  # voltage scan range in mV in absolute value
 
 vols=[]
 mvols=[]
@@ -41,10 +41,9 @@ iStep=int(sign*1.0*1e3)
 for iBias in range(iStart,iEnd,iStep):
     biasSupply.output_on()
     biasvol=iBias/1000 # mV to V
-	#if biasvol>2:
-    #    break
     vols.append(biasvol)
     mvols.append(biasSupply.set_voltage(biasvol))
+    time.sleep(0.5)
     current.append(biasSupply.display_current())
     if biasSupply.hit_compliance():
         break
@@ -59,5 +58,7 @@ dataarray=np.array(data)
 filename="test.csv"
 csv_writer(dataarray.T,filename)
 
+print("Ramping down...")
 biasSupply.set_voltage(0*1e3)
 biasSupply.output_off()
+biasSupply.beep()

--- a/scanIV2.py
+++ b/scanIV2.py
@@ -53,6 +53,7 @@ for iBias in range(iStart,iEnd,iStep):
     #    break
     vols.append(biasvol)
     mvols.append(biasSupply.set_voltage(biasvol))
+    time.sleep(0.5)
     current_sig.append(curMeter.display_current())
     current_tot.append(biasSupply.display_current())
     if biasSupply.hit_compliance():
@@ -71,6 +72,8 @@ dataarray=np.array(data)
 filename="test.csv"
 csv_writer(dataarray.T,filename)
 
+print("Ramping down...")
 biasSupply.set_voltage(0*1e3)
 biasSupply.output_off()
 curMeter.output_off()
+biasSupply.beep()


### PR DESCRIPTION
Update the ramping scheme:
- Harmonize to the same speed for ramping up and down to avoid potential difference in applying positive and negative high voltage.
- Update the ramping step from 1V per step per second to 0.1V per step per 0.1 second to avoid large current in CV scan.

Move time.sleep() functions from instrument controller scripts to user scan scripts to allow easy estimation and flexible configuration of the scan time.

Add a beeper sound at the end of each scan.

Set negative HV as default for CV scan.